### PR TITLE
Make hand gray when picking

### DIFF
--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -29,7 +29,8 @@
   let ending = false
   let numGaps = 0
   let allowChoose = false
-  var lastChooseState = false
+  var needsPickerUpdate = false
+  var lastStatus = ""
 
   let allowPick = false
   let isSpectator = false
@@ -62,6 +63,12 @@
   function updateStatus(data) {
     countDown = data.timer
     $("#matchstatus").html(data.status)
+    if (lastStatus !== data.status) {
+    	if (data.status === "Players are choosing cards...") {
+    		needsPickerUpdate = true
+    	}
+    }
+    lastStatus = data.status
     ending = data.ending
     numGaps = data.gaps
     allowChoose = data.allowChoose
@@ -269,7 +276,7 @@
       container.empty().append(createSystemCard())
     }
 
-    if (lastChooseState !== allowChoose) {
+    if (needsPickerUpdate) {
     	var objects = $(".tab-objects").find(".card-base")
     	for (var i = 0; i < objects.length; i++) {
     		if (allowChoose) {
@@ -286,8 +293,8 @@
 				objects[i].classList.remove("verb-card")
     		}
     	}
+    	needsPickerUpdate = false
     }
-    lastChooseState = allowChoose
   }
 
   /**

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -3,6 +3,7 @@
  *
  * MIT License
  * Copyright (c) 2017-2018 LordKorea
+ * Copyright (c) 2018 Arc676/Alessandro Vinciguerra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -29,6 +29,8 @@
   let ending = false
   let numGaps = 0
   let allowChoose = false
+  var lastChooseState = false
+
   let allowPick = false
   let isSpectator = false
   let externalUpdateAllowed = true
@@ -266,6 +268,18 @@
     } else {
       container.empty().append(createSystemCard())
     }
+
+    if (lastChooseState !== allowChoose) {
+    	var objects = $(".tab-objects").find(".card-base")
+    	for (var i = 0; i < objects.length; i++) {
+    		objects[i].classList.toggle("object-card")
+    	}
+    	objects = $(".tab-actions").find(".card-base")
+    	for (var i = 0; i < objects.length; i++) {
+    		objects[i].classList.toggle("verb-card")
+    	}
+    }
+    lastChooseState = allowChoose
   }
 
   /**

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -272,11 +272,19 @@
     if (lastChooseState !== allowChoose) {
     	var objects = $(".tab-objects").find(".card-base")
     	for (var i = 0; i < objects.length; i++) {
-    		objects[i].classList.toggle("object-card")
+    		if (allowChoose) {
+				objects[i].classList.add("object-card")
+    		} else {
+				objects[i].classList.remove("object-card")
+			}
     	}
     	objects = $(".tab-actions").find(".card-base")
     	for (var i = 0; i < objects.length; i++) {
-    		objects[i].classList.toggle("verb-card")
+    		if (allowChoose) {
+				objects[i].classList.add("verb-card")
+    		} else {
+				objects[i].classList.remove("verb-card")
+    		}
     	}
     }
     lastChooseState = allowChoose


### PR DESCRIPTION
I couldn't figure out how to gray out the cards. One possible solution is to loop though all the cards in your hand and change the class, but I couldn't find a way to get all the cards. Is there a way to get them from this container?
```
let container = $(`#${lowerType}-hand`)
```

Possible alternative to #22, implemented here: hide the cards completely.