### PR TITLE
Added button to skip countdown to next phase

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -139,6 +139,36 @@ Returns a JSON object of the following format:
 ```
 
 
+## /api/skip
+
+|Requirements|Request Type|
+|---|---|
+|Logged in, in match, and owns match|POST|
+
+Skips directly to the next phase.
+
+### Parameters
+
+None.
+
+### Response format
+
+A JSON object is returned.
+
+|Key|Type|Description|
+|---|---|---|
+|error|string|A short message indicating the result of the operation. `OK` on success.|
+
+### Example
+
+```
+> POST /api/skip
+{
+  "error": "OK"
+}
+```
+
+
 ## /api/chat
 
 |Requirements|Request Type|

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -306,10 +306,6 @@ class Match:
 
     def skip_to_next_phase(self):
         """Skips directly to the next phase
-
-        Contract:
-            The match's instance lock has to be locked when calling this
-            method.
         """
         self._timer = time()
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -53,6 +53,7 @@ class Match:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
         skip_role (str): Which users are allowed to skip the current phase.
+        skip_count (int): Number of people who want to skip the phase.
     """
 
     # The minimum amount of players for a match
@@ -98,6 +99,7 @@ class Match:
 
     # Which users are allowed to skip the phase
     skip_role = "owner"
+    skip_count = 0
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -326,6 +328,14 @@ class Match:
             return False
         elif self.skip_role == "anyone":
             return True
+        elif self.skip_role == "majority":
+            self.skip_count += 1
+            majority = int(len(list(self.get_participants(False))) / 2)
+            if self.skip_count > majority:
+                self.skip_count = 0
+                return True
+            else:
+                return False
         else:
             return self.get_owner_nick() == nickname
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -307,9 +307,12 @@ class Match:
     def skip_to_next_phase(self):
         """Skips directly to the next phase
         """
-        self._timer = time()
-        self._chat.append(("SYSTEM",
-                           "<b>" + self.get_owner_nick() + " skipped to next phase</b>"))
+        if int(self._timer - time()) > 1:
+            self._timer = time()
+            self._chat.append(("SYSTEM",
+                               "<b>" + self.get_owner_nick() + " skipped to next phase</b>"))
+        else:
+            self._chat.append(("SYSTEM", "<b>Can't skip phase with less than 1 second remaining</b>"))
 
     def _set_state(self, state):
         """Updates the state for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -322,10 +322,13 @@ class Match:
             can skip to the next phase
         """
         if self.skip_role == "picker":
-            for part in self.get_participants(False):
-                if part.picking and part.nickname == nickname:
-                    return True
-            return False
+            if self._state == "CHOOSING":
+                for part in self.get_participants(False):
+                    if part.picking and part.nickname == nickname:
+                        return True
+                return False
+            else:
+                return True
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -37,6 +37,7 @@ from random import shuffle
 from threading import RLock
 from time import time
 
+from nussschale.nussschale import nconfig
 from model.multideck import MultiDeck
 from nussschale.util.locks import mutex, named_mutex
 
@@ -51,6 +52,7 @@ class Match:
     Class Attributes:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
+        skip_role (str): Which users are allowed to skip the current phase.
     """
 
     # The minimum amount of players for a match
@@ -93,6 +95,9 @@ class Match:
 
     # Whether matches are currently frozen
     frozen = False
+
+    # Which users are allowed to skip the phase
+    skip_role = "owner"
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -228,6 +233,9 @@ class Match:
         # The chat of this match, tuples with type/message
         self._chat = [("SYSTEM", "<b>Match was created.</b>")]
 
+        # Which users are allowed to skip the phase
+        self.skip_role = nconfig().get("skip-role", "owner")
+
     def put_in_pool(self):
         """Puts this match into the match pool."""
         Match.add_match(self.id, self)
@@ -311,18 +319,29 @@ class Match:
             bool: Whether the given nickname belongs to a user that
             can skip to the next phase
         """
-        # Currently, only the owner can skip to the next phase
-        return self.get_owner_nick() == nickname
+        if self.skip_role == "picker":
+            for part in self.get_participants(False):
+                if part.picking and part.nickname == nickname:
+                    return True
+            return False
+        elif self.skip_role == "anyone":
+            return True
+        else:
+            return self.get_owner_nick() == nickname
 
-    def skip_to_next_phase(self):
+    def skip_to_next_phase(self, nick):
         """Skips directly to the next phase
+
+        Args:
+            nick (str): The nickname of the user who is skipping the phase.
         """
         if int(self._timer - time()) > 1:
             self._timer = time()
             self._chat.append(("SYSTEM",
-                               "<b>" + self.get_owner_nick() + " skipped to next phase</b>"))
+                               "<b>" + nick + " skipped to next phase</b>"))
         else:
-            self._chat.append(("SYSTEM", "<b>Can't skip phase with less than 1 second remaining</b>"))
+            self._chat.append(("SYSTEM",
+                "<b>Can't skip phase with less than 1 second remaining</b>"))
 
     def _set_state(self, state):
         """Updates the state for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -308,6 +308,8 @@ class Match:
         """Skips directly to the next phase
         """
         self._timer = time()
+        self._chat.append(("SYSTEM",
+                           "<b>" + self.get_owner_nick() + " skipped to next phase</b>"))
 
     def _set_state(self, state):
         """Updates the state for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -304,6 +304,15 @@ class Match:
         # Locking is not needed here as access is atomic.
         return int(self._timer - time())
 
+    def skip_to_next_phase(self):
+        """Skips directly to the next phase
+
+        Contract:
+            The match's instance lock has to be locked when calling this
+            method.
+        """
+        self._timer = time()
+
     def _set_state(self, state):
         """Updates the state for this match.
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -304,6 +304,16 @@ class Match:
         # Locking is not needed here as access is atomic.
         return int(self._timer - time())
 
+    def user_can_skip_phase(self, nickname):
+        """Determine whether a user can skip to the next phase
+
+        Returns:
+            bool: Whether the given nickname belongs to a user that
+            can skip to the next phase
+        """
+        # Currently, only the owner can skip to the next phase
+        return self.get_owner_nick() == nickname
+
     def skip_to_next_phase(self):
         """Skips directly to the next phase
         """

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -315,8 +315,7 @@ def api_skip(ctx: EndpointContext) -> None:
         raise HTTPException.forbidden(True, "not match owner")
 
     # Skip remaining time
-    # once I figure out how to...
-    print("Owner tried to skip time!")
+    match.skip_to_next_phase()
     ctx.json_ok()
 
 

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -303,7 +303,7 @@ def api_skip(ctx: EndpointContext) -> None:
 
     Raises:
         HTTPException: (403) When the user is not in a match,
-                             or invalid data is sent.
+                             or user is not authorized to skip phases.
     """
     match = Match.get_match_of_player(ctx.session["id"])
     if match is None:
@@ -311,9 +311,9 @@ def api_skip(ctx: EndpointContext) -> None:
 
     part = match.get_participant(ctx.session["id"])
 
-    # Check that the POST request was made by the owner
-    if match.get_owner_nick() != part.nickname:
-        raise HTTPException.forbidden(True, "not match owner")
+    # Check that the POST request was made by a user that can skip phases
+    if not match.user_can_skip_phase(part.nickname):
+        raise HTTPException.forbidden(True, "not authorized to skip phase")
 
     # Skip remaining time
     match.skip_to_next_phase()

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -316,7 +316,7 @@ def api_skip(ctx: EndpointContext) -> None:
         raise HTTPException.forbidden(True, "not authorized to skip phase")
 
     # Skip remaining time
-    match.skip_to_next_phase(part.nickname)
+    match.skip_to_next_phase()
     ctx.json_ok()
 
 

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -293,6 +293,34 @@ def api_chat_send(ctx: EndpointContext) -> None:
 
 
 @Endpoint(APILeaf)
+@RequirePath("skip")
+def api_skip(ctx: EndpointContext) -> None:
+    """Skips directly to the next phase
+
+    Args:
+        ctx: The context of the request
+
+    Raises:
+        HTTPException: (403) When the user is not in a match,
+                             or invalid data is sent.
+    """
+    match = Match.get_match_of_player(ctx.session["id"])
+    if match is None:
+        raise HTTPException.forbidden(True, "not in match")
+
+    part = match.get_participant(ctx.session["id"])
+
+    # Check that the POST request was made by the owner
+    if match.get_owner_nick() != part.nickname:
+        raise HTTPException.forbidden(True, "not match owner")
+
+    # Skip remaining time
+    # once I figure out how to...
+    print("Owner tried to skip time!")
+    ctx.json_ok()
+
+
+@Endpoint(APILeaf)
 @RequirePath("chat")
 def api_chat(ctx: EndpointContext) -> None:
     """Retrieves the chat history, optionally starting at the given offset.

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -2,6 +2,7 @@
 
 MIT License
 Copyright (c) 2017-2018 LordKorea
+Copyright (c) 2018 Arc676/Alessandro Vinciguerra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -316,7 +316,7 @@ def api_skip(ctx: EndpointContext) -> None:
         raise HTTPException.forbidden(True, "not authorized to skip phase")
 
     # Skip remaining time
-    match.skip_to_next_phase()
+    match.skip_to_next_phase(part.nickname)
     ctx.json_ok()
 
 

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -412,6 +412,16 @@
     pickTab("tab-objects")
   }
 
+  /**
+   * Sends POST request to skip the remaining time
+   */
+  function skipTime() {
+    $.ajax({
+      method: "POST",
+      url: "/api/skip"
+    })
+  }
+
   setInterval(loadStatus, 1000)
   loadStatus()
   setInterval(loadCards, 1000)
@@ -419,4 +429,5 @@
   pickTab("tab-actions")
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
+  $("#skip-button").click(skipTime)
 })()

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -424,6 +424,7 @@
       method: "POST",
       url: "/api/skip"
     })
+  }
 
   /*
    * Toggle hand visibility.

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -424,7 +424,6 @@
       method: "POST",
       url: "/api/skip"
     })
-  }
 
   /*
    * Toggle hand visibility.

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -38,6 +38,7 @@
             <div class="countdown-clock" id="countdown">
               00:00
             </div>
+            <input type="button" id="skip-button" value="Skip to next phase">
             <div class="card-base system-card sticky-card" id="match-statement">
               Waiting...
             </div>


### PR DESCRIPTION
I added a new API endpoint to skip the remaining time and a simple button to the match page that sends the corresponding POST request.

For now, only the owner of a match may skip the remaining time. Maybe it should be changed so that only the current picker can skip the time.

I've never done multithreading in Python, so it's possible that modifications will have to be made to prevent concurrent access to `match.skip_to_next_phase` but I'm not sure.

Closes #33.