### PR TITLE
Toggle hand/chat visibility

### DIFF
--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -430,7 +430,7 @@
    * Toggle hand visibility
    */
    function toggleHand() {
-     $("#hand-container").hide()
+     $("#hand-container").toggle()
    }
 
   setInterval(loadStatus, 1000)

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -416,6 +416,16 @@
     pickTab("tab-objects")
   }
 
+  /**
+   * Sends POST request to skip the remaining time
+   */
+  function skipTime() {
+    $.ajax({
+      method: "POST",
+      url: "/api/skip"
+    })
+  }
+
   setInterval(loadStatus, 1000)
   loadStatus()
   setInterval(loadCards, 1000)
@@ -423,4 +433,5 @@
   pickTab("tab-actions")
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
+  $("#skip-button").click(skipTime)
 })()

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -426,6 +426,13 @@
     })
   }
 
+  /**
+   * Toggle hand visibility
+   */
+   function toggleHand() {
+     $("#hand-container").hide()
+   }
+
   setInterval(loadStatus, 1000)
   loadStatus()
   setInterval(loadCards, 1000)
@@ -434,4 +441,5 @@
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
   $("#skip-button").click(skipTime)
+  $("#toggle-hand-button").click(toggleHand)
 })()

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -417,16 +417,6 @@
   }
 
   /**
-   * Sends POST request to skip the remaining time
-   */
-  function skipTime() {
-    $.ajax({
-      method: "POST",
-      url: "/api/skip"
-    })
-  }
-
-  /**
    * Toggle hand visibility
    */
    function toggleHand() {
@@ -449,7 +439,6 @@
   pickTab("tab-actions")
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
-  $("#skip-button").click(skipTime)
   $("#toggle-hand-button").click(toggleHand)
   $("#toggle-chat-button").click(toggleChat)
 })()

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -433,6 +433,13 @@
      $("#hand-container").toggle()
    }
 
+   /**
+    * Toggle chat visibility
+    */
+  function toggleChat() {
+    $("#chat-container").toggle()
+  }
+
   setInterval(loadStatus, 1000)
   loadStatus()
   setInterval(loadCards, 1000)
@@ -442,4 +449,5 @@
   $("#tab-objects").click(chooseObjectsTab)
   $("#skip-button").click(skipTime)
   $("#toggle-hand-button").click(toggleHand)
+  $("#toggle-chat-button").click(toggleChat)
 })()

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -431,6 +431,7 @@
    */
    function toggleHand() {
      $("#hand-container").toggle()
+     $("#toggle-hand-button").html(($("#hand-container").is(":visible") ? "Hide" : "Show") + " Hand")
    }
 
    /**
@@ -438,6 +439,7 @@
     */
   function toggleChat() {
     $("#chat-container").toggle()
+    $("#toggle-chat-button").html(($("#chat-container").is(":visible") ? "Hide" : "Show") + "  Chat")
   }
 
   setInterval(loadStatus, 1000)

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -22,6 +22,10 @@
           Toggle Hand Visibility
         </a>
         &nbsp;
+        <a href="#" id="toggle-chat-button">
+          Toggle Chat Visibility
+        </a>
+        &nbsp;
         <a href="#" id="lightLabel">
           Lights are being checked...
         </a>
@@ -50,7 +54,7 @@
           <div class="match-played-cards"></div>
         </div>
       </div>
-      <div class="match-chat">
+      <div id="chat-container" class="match-chat">
         <input type="text" class="chat-line" id="chatinput" placeholder="Type a message..." spellcheck="false" maxlength="120" autocomplete="off">
         <div class="chat-messages" id="chatlist"></div>
       </div>

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -52,7 +52,8 @@
       </div>
     </div>
     <div class="match-hand">
-      <div class="match-hand-container">
+      <input type="button" id="toggle-hand-button" value="Toggle hand">
+      <div id="hand-container" class="match-hand-container">
         <div class="match-hand-tabs">
           <div class="hand-tab-header" id="tab-actions">
             Actions

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -18,6 +18,10 @@
         <a href="/match/abandon">Abandon match</a>
       </div>
       <div>
+        <a href="#" id="toggle-hand-button">
+          Toggle Hand Visibility
+        </a>
+        &nbsp;
         <a href="#" id="lightLabel">
           Lights are being checked...
         </a>
@@ -52,7 +56,6 @@
       </div>
     </div>
     <div class="match-hand">
-      <input type="button" id="toggle-hand-button" value="Toggle hand">
       <div id="hand-container" class="match-hand-container">
         <div class="match-hand-tabs">
           <div class="hand-tab-header" id="tab-actions">

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -19,11 +19,11 @@
       </div>
       <div>
         <a href="#" id="toggle-hand-button">
-          Toggle Hand Visibility
+          Hide Hand
         </a>
         &nbsp;
         <a href="#" id="toggle-chat-button">
-          Toggle Chat Visibility
+          Hide Chat
         </a>
         &nbsp;
         <a href="#" id="lightLabel">


### PR DESCRIPTION
Added two hyperlinks for toggling the visibility of game components. One shows/hides the user's hand and the other shows/hides the chat. Text adapts to say "show" or "hide" based on the current visibility.

Closes #35.