### PR TITLE
Kick AFK Players

### DIFF
--- a/src/model/match.py
+++ b/src/model/match.py
@@ -787,11 +787,11 @@ class Match:
         return res
 
     @mutex
-    def send_message(self, nick, msg):
+    def send_message(self, part, msg):
         """Sends a user message to the chat of this match.
 
         Args:
-            nick (str): The nickname of the user.
+            part (Participant): The user who sent the message.
             msg (str): The message that is sent to the chat.
 
         Contract:
@@ -800,7 +800,8 @@ class Match:
         msg = re.sub("(https?://\\S+)",
                      "<a href=\"\\1\" target=\"_blank\">\\1</a>",
                      msg)
-        self._chat.append(("USER", "<b>%s</b>: %s" % (nick, msg)))
+        self._chat.append(("USER", "<b>%s</b>: %s" % (part.nickname, msg)))
+        self.afk_players[part.id] = 0
 
     @mutex
     def declare_round_winner(self, order):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -366,10 +366,10 @@ class Match:
             can_pick = self._pick_possible()
 
             # Kick AFK players
-            for (player, afkRounds) in self.afk_players.items():
+            for (pid, afkRounds) in self.afk_players.items():
                 if afkRounds >= 2:
                     # Kick player for doing nothing for two rounds
-                    self._chat.append(("SYSTEM", player + " has been AFK for two rounds!"))
+                    self.abandon_participant(pid)
 
             # If no pick is possible (too few valid hands) then skip the round
             if not can_pick:
@@ -576,7 +576,7 @@ class Match:
         self._participants[id] = part
         if not part.spectator:
             self._chat.append(("SYSTEM", "<b>%s joined.</b>" % nick))
-            self.afk_players[nick] = 0
+            self.afk_players[id] = 0
         else:
             self._chat.append(("SYSTEM",
                                "<b>%s is now spectating.</b>" % nick))
@@ -872,9 +872,9 @@ class Match:
             # Find players who haven't played
             if part.choose_count() > 0:
                 n += 1
-                self.afk_players[part.nickname] = 0
+                self.afk_players[part.id] = 0
             else:
-                self.afk_players[part.nickname] += 1
+                self.afk_players[part.id] += 1
         return n >= 2
 
     def _unchoose_incomplete(self):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -369,7 +369,7 @@ class Match:
             for (pid, afkRounds) in self.afk_players.items():
                 if afkRounds >= 2:
                     # Kick player for doing nothing for two rounds
-                    self.abandon_participant(pid)
+                    self.abandon_participant(pid, "was kicked for being AFK for two rounds.")
 
             # If no pick is possible (too few valid hands) then skip the round
             if not can_pick:
@@ -466,7 +466,7 @@ class Match:
                 del self._participants[pid]
 
     @mutex
-    def abandon_participant(self, pid):
+    def abandon_participant(self, pid, message="left."):
         """Removes the given participant from the match.
 
         Args:
@@ -480,7 +480,7 @@ class Match:
             return
         nick = self._participants[pid].nickname
         self._chat.append(("SYSTEM",
-                           "<b>%s left.</b>" % nick))
+                           "<b>%s %s</b>" % (nick, message)))
         if self._participants[pid].picking:
             self.notify_picker_leave(pid)
         del self._participants[pid]
@@ -873,7 +873,7 @@ class Match:
             if part.choose_count() > 0:
                 n += 1
                 self.afk_players[part.id] = 0
-            else:
+            elif not part.picking:
                 self.afk_players[part.id] += 1
         return n >= 2
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -818,6 +818,8 @@ class Match:
         winner = None
         for part in self.get_participants(False):
             if part.picking or part.choose_count() < gc:
+                if part.picking:
+                    self.afk_players[part.id] = 0
                 continue
             if part.order == order:
                 winner = part

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -52,6 +52,7 @@ class Participant:
             occurring.
         order: The order key of the particpant, used for shuffling.
         spectator: Whether the participant is a spectator.
+        afkCount: The number of rounds the participant has spent AFK.
     """
 
     # The number of hand cards per type
@@ -59,6 +60,9 @@ class Participant:
 
     # The timeout timer after refreshing a participant, in seconds
     _PARTICIPANT_REFRESH_TIMER = 15
+
+    # Rounds spent AFK
+    afkCount = 0
 
     def __init__(self, id: str, nickname: str) -> None:
         """Constructor.
@@ -116,6 +120,24 @@ class Participant:
         """
         assert not self.spectator, "Trying to increase score for spectator"
         self.score += 1
+
+    @mutex
+    def increase_AFK(self) -> None:
+        """Increases AFK count by one.
+
+        Contract:
+            This method locks the particpant's lock.
+        """
+        self.afkCount += 1
+
+    @mutex
+    def reset_AFK(self) -> None:
+        """Reset the particpant's AFK count to zero.
+
+        Contract:
+            This method locks the particpant's lock.
+        """
+        self.afkCount = 0
 
     def refresh(self) -> None:
         """Refreshes the timeout timer of this participant."""

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -286,7 +286,7 @@ def api_chat_send(ctx: EndpointContext) -> None:
     # Check the chat message for sanity
     if 0 < len(msg) < 200:
         # Send the message
-        match.send_message(part.nickname, msg)
+        match.send_message(part, msg)
         ctx.json_ok()
     else:
         raise HTTPException.forbidden(True, "invalid size")


### PR DESCRIPTION
The `Match` class now keeps a record of how many rounds players spent exhibiting AFK-behavior. If a picker does not choose a winner or does not choose a card, this counts as AFK-activity. Choosing a card or picking a winner resets the player's AFK round count to 0. If any player's AFK round count is at least 2 during the COOLDOWN phase, that player is kicked, ungracefully i.e. the client's UI freezes. This should be improved (send a message to the client and show an error page or something).

Not picking a winner when there aren't enough choices does not count as AFK-behavior.

Kicking players for being AFK for too long adds a custom error message to the chat.

Closes #19.