### PR TITLE
Made bang.svg shorter

### DIFF
--- a/src/res/images/bang.svg
+++ b/src/res/images/bang.svg
@@ -3,6 +3,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="8px" height="8px" viewBox="0 0 8 8" enable-background="new 0 0 8 8" xml:space="preserve">
-<rect x="2.989" width="2.023" height="5.471"/>
-<rect x="2.989" y="6.39" width="2.023" height="1.61"/>
+<rect x="2.989" width="2.023" height="4.971"/>
+<rect x="2.989" y="5.89" width="2.023" height="1.61"/>
 </svg>


### PR DESCRIPTION
Made the SVG for the exclamation mark slightly shorter so they don't overlap in the chat.

![screen shot](https://user-images.githubusercontent.com/30745465/35773548-953f6db2-0990-11e8-9a45-1f3d5f3afa48.jpg)

Closes #45