### PR TITLE
Configurable wild replacement

### DIFF
--- a/src/model/match.py
+++ b/src/model/match.py
@@ -959,9 +959,12 @@ class Match:
             The caller ensures that the match's lock is held when calling this
             method.
         """
+        card_count = self.total_cards
         for part in self.get_participants(False):
-            part.replenish_hand(self._multidecks,
-                                self.total_cards)
+            card_count -= part.get_card_count()
+        for part in self.get_participants(False):
+            drawn = part.replenish_hand(self._multidecks, card_count)
+            card_count -= drawn
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -37,6 +37,7 @@ from random import shuffle
 from threading import RLock
 from time import time
 
+from nussschale.nussschale import nconfig
 from model.multideck import MultiDeck
 from nussschale.util.locks import mutex, named_mutex
 
@@ -51,6 +52,7 @@ class Match:
     Class Attributes:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
+        skip_role (str): Which users are allowed to skip the current phase.
     """
 
     # The minimum amount of players for a match
@@ -93,6 +95,9 @@ class Match:
 
     # Whether matches are currently frozen
     frozen = False
+
+    # Which users are allowed to skip the phase
+    skip_role = "owner"
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -228,6 +233,9 @@ class Match:
         # The chat of this match, tuples with type/message
         self._chat = [("SYSTEM", "<b>Match was created.</b>")]
 
+        # Which users are allowed to skip the phase
+        self.skip_role = nconfig().get("skip-role", "owner")
+
     def put_in_pool(self):
         """Puts this match into the match pool."""
         Match.add_match(self.id, self)
@@ -314,6 +322,7 @@ class Match:
         Returns:
             bool: Whether the given participant can skip to the next phase
         """
+
         # The match must not be ending
         if self._state == "ENDING":
             return False
@@ -322,23 +331,29 @@ class Match:
         if len(self._participants) < Match._MINIMUM_PLAYERS:
             return False
 
-        # Currently, only the owner can skip to the next phase
-        return self.get_owner_nick() == part.nickname
+        if self.skip_role == "picker":
+            for part in self.get_participants(False):
+                if part.picking and part.nickname == nickname:
+                    return True
+            return False
+        elif self.skip_role == "anyone":
+            return True
+        else:
+            return self.get_owner_nick() == nickname
 
     @mutex
-    def skip_to_next_phase(self):
-        """Skips directly to the next phase.
+    def skip_to_next_phase(self, nick):
+        """Skips directly to the next phase
 
-        Contract:
-            This method locks the match's instance lock.
+        Args:
+            nick (str): The nickname of the user who is skipping the phase.
         """
         # One second difference to prevent edge cases of timer change close to
         # game state transitions.
         if self._timer - time() > 1:
             self._timer = time()
             self._chat.append(("SYSTEM",
-                               "<b>" + self.get_owner_nick()
-                               + " skipped to the next phase.</b>"))
+                               "<b>" + nick + " skipped to next phase</b>"))
 
     def _set_state(self, state):
         """Updates the state for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -101,7 +101,6 @@ class Match:
 
     # Wild card data
     wild_card_count = 0
-    wilds_in_play = 0
     total_cards = 0
 
     @classmethod
@@ -961,7 +960,7 @@ class Match:
             method.
         """
         for part in self.get_participants(False):
-            part.replenish_hand(self._multidecks, self.wilds_in_play,
+            part.replenish_hand(self._multidecks,
                                 self.total_cards)
 
     def _select_match_card(self):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -350,6 +350,11 @@ class Match:
                 self.skip_count = 0
                 return True
             else:
+                self._chat.append(("SYSTEM",
+                                   "<b>" + nickname +
+                                   " wants to skip the phase. " +
+                                   str(majority - self.skip_count + 1) +
+                                   " request(s) left to reach majority.</b>"))
                 return False
         else:
             return self.get_owner_nick() == nickname

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -339,7 +339,7 @@ class Match:
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":
-            particpant.wants_skip = True
+            participant.wants_skip = True
             skip_count = 0
             for part in self.get_participants(False):
                 if part.wants_skip:

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -338,6 +338,11 @@ class Match:
                 self.skip_count = 0
                 return True
             else:
+                self._chat.append(("SYSTEM",
+                                   "<b>" + nickname +
+                                   " wants to skip the phase. " +
+                                   str(majority - self.skip_count + 1) +
+                                   " request(s) left to reach majority.</b>"))
                 return False
         else:
             return self.get_owner_nick() == nickname

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -53,6 +53,7 @@ class Match:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
         skip_role (str): Which users are allowed to skip the current phase.
+        skip_count (int): Number of people who want to skip the phase.
     """
 
     # The minimum amount of players for a match
@@ -98,6 +99,7 @@ class Match:
 
     # Which users are allowed to skip the phase
     skip_role = "owner"
+    skip_count = 0
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -326,6 +328,14 @@ class Match:
             return False
         elif self.skip_role == "anyone":
             return True
+        elif self.skip_role == "majority":
+            self.skip_count += 1
+            majority = int(len(list(self.get_participants(False))) / 2)
+            if self.skip_count > majority:
+                self.skip_count = 0
+                return True
+            else:
+                return False
         else:
             return self.get_owner_nick() == nickname
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -334,10 +334,13 @@ class Match:
             return False
 
         if self.skip_role == "picker":
-            for part in self.get_participants(False):
-                if part.picking and part.nickname == nickname:
-                    return True
-            return False
+            if self._state == "CHOOSING":
+                for part in self.get_participants(False):
+                    if part.picking and part.nickname == nickname:
+                        return True
+                return False
+            else:
+                return True
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -716,7 +716,7 @@ class Match:
             self._multidecks[type] = MultiDeck[Card, int](self._deck[type])
             self.total_cards += len(self._deck[type])
 
-        wilds = [Card(card_id_counter + 1 + i, "WILD", "")
+        wilds = [Card(card_id_counter + 1 + i, "WILD", "Wild card")
                 for i in range(self.wild_card_count)]
         self._multidecks["WILD"] = MultiDeck[Card, int](wilds)
         self.total_cards += self.wild_card_count

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -53,6 +53,7 @@ class Match:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
         skip_role (str): Which users are allowed to skip the current phase.
+        skip_count (int): Number of people who want to skip the phase.
     """
 
     # The minimum amount of players for a match
@@ -98,6 +99,7 @@ class Match:
 
     # Which users are allowed to skip the phase
     skip_role = "owner"
+    skip_count = 0
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -338,6 +340,14 @@ class Match:
             return False
         elif self.skip_role == "anyone":
             return True
+        elif self.skip_role == "majority":
+            self.skip_count += 1
+            majority = int(len(list(self.get_participants(False))) / 2)
+            if self.skip_count > majority:
+                self.skip_count = 0
+                return True
+            else:
+                return False
         else:
             return self.get_owner_nick() == nickname
 

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -53,7 +53,6 @@ class Match:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
         skip_role (str): Which users are allowed to skip the current phase.
-        skip_count (int): Number of people who want to skip the phase.
     """
 
     # The minimum amount of players for a match
@@ -99,7 +98,6 @@ class Match:
 
     # Which users are allowed to skip the phase
     skip_role = "owner"
-    skip_count = 0
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -315,11 +313,8 @@ class Match:
         return int(self._timer - time())
 
     @mutex
-    def user_can_skip_phase(self, part):
-        """Determine whether a user can skip to the next phase.
-
-        Args:
-            obj: The participant in question.
+    def user_can_skip_phase(self, participant):
+        """Determine whether a user can skip to the next phase
 
         Returns:
             bool: Whether the given participant can skip to the next phase
@@ -344,20 +339,25 @@ class Match:
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":
-            self.skip_count += 1
+            particpant.wants_skip = True
+            skip_count = 0
+            for part in self.get_participants(False):
+                if part.wants_skip:
+                    skip_count += 1
             majority = int(len(list(self.get_participants(False))) / 2)
-            if self.skip_count > majority:
-                self.skip_count = 0
+            if skip_count > majority:
+                for part in self.get_participants(False):
+                    part.wants_skip = False
                 return True
             else:
                 self._chat.append(("SYSTEM",
-                                   "<b>" + nickname +
+                                   "<b>" + participant.nickname +
                                    " wants to skip the phase. " +
-                                   str(majority - self.skip_count + 1) +
+                                   str(majority - skip_count + 1) +
                                    " request(s) left to reach majority.</b>"))
                 return False
         else:
-            return self.get_owner_nick() == nickname
+            return self.get_owner_nick() == participant.nickname
 
     @mutex
     def skip_to_next_phase(self, nick):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -99,6 +99,10 @@ class Match:
     # Which users are allowed to skip the phase
     skip_role = "owner"
 
+    # Number of wild cards in the match
+    wild_card_count = 0
+    wild_cards_played = 0
+
     @classmethod
     @named_mutex("_pool_lock")
     def get_by_id(cls, id):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -101,7 +101,6 @@ class Match:
 
     # Wild card data
     wild_card_count = 0
-    wilds_in_play = 0
     total_cards = 0
 
     @classmethod
@@ -970,7 +969,7 @@ class Match:
             method.
         """
         for part in self.get_participants(False):
-            part.replenish_hand(self._multidecks, self.wilds_in_play,
+            part.replenish_hand(self._multidecks,
                                 self.total_cards)
 
     def _select_match_card(self):

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -991,7 +991,7 @@ class Match:
             return
         for card in cards:
             if card.type == "WILD":
-                self.mdecks["WILD"].putInQueue(card)
+                self._multidecks["WILD"].put_in_queue(card)
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -322,10 +322,13 @@ class Match:
             can skip to the next phase
         """
         if self.skip_role == "picker":
-            for part in self.get_participants(False):
-                if part.picking and part.nickname == nickname:
-                    return True
-            return False
+            if self._state == "CHOOSING":
+                for part in self.get_participants(False):
+                    if part.picking and part.nickname == nickname:
+                        return True
+                return False
+            else:
+                return True
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -37,6 +37,7 @@ from random import shuffle
 from threading import RLock
 from time import time
 
+from nussschale.nussschale import nconfig
 from model.multideck import MultiDeck
 from nussschale.util.locks import mutex, named_mutex
 
@@ -51,6 +52,7 @@ class Match:
     Class Attributes:
         frozen (bool): Whether matches are currently frozen, i.e. whether their
             state transitions are disabled.
+        skip_role (str): Which users are allowed to skip the current phase.
     """
 
     # The minimum amount of players for a match
@@ -93,6 +95,9 @@ class Match:
 
     # Whether matches are currently frozen
     frozen = False
+
+    # Which users are allowed to skip the phase
+    skip_role = "owner"
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -228,6 +233,9 @@ class Match:
         # The chat of this match, tuples with type/message
         self._chat = [("SYSTEM", "<b>Match was created.</b>")]
 
+        # Which users are allowed to skip the phase
+        self.skip_role = nconfig().get("skip-role", "owner")
+
     def put_in_pool(self):
         """Puts this match into the match pool."""
         Match.add_match(self.id, self)
@@ -311,18 +319,29 @@ class Match:
             bool: Whether the given nickname belongs to a user that
             can skip to the next phase
         """
-        # Currently, only the owner can skip to the next phase
-        return self.get_owner_nick() == nickname
+        if self.skip_role == "picker":
+            for part in self.get_participants(False):
+                if part.picking and part.nickname == nickname:
+                    return True
+            return False
+        elif self.skip_role == "anyone":
+            return True
+        else:
+            return self.get_owner_nick() == nickname
 
-    def skip_to_next_phase(self):
+    def skip_to_next_phase(self, nick):
         """Skips directly to the next phase
+
+        Args:
+            nick (str): The nickname of the user who is skipping the phase.
         """
         if int(self._timer - time()) > 1:
             self._timer = time()
             self._chat.append(("SYSTEM",
-                               "<b>" + self.get_owner_nick() + " skipped to next phase</b>"))
+                               "<b>" + nick + " skipped to next phase</b>"))
         else:
-            self._chat.append(("SYSTEM", "<b>Can't skip phase with less than 1 second remaining</b>"))
+            self._chat.append(("SYSTEM",
+                "<b>Can't skip phase with less than 1 second remaining</b>"))
 
     def _set_state(self, state):
         """Updates the state for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -1000,7 +1000,7 @@ class Match:
             return
         for card in cards:
             if card.type == "WILD":
-                self.mdecks["WILD"].putInQueue(card)
+                self._multidecks["WILD"].put_in_queue(card)
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -102,6 +102,7 @@ class Match:
     # Wild card data
     wild_card_count = 0
     total_cards = 0
+    wild_replace_mode = "no"
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -239,6 +240,9 @@ class Match:
 
         # Which users are allowed to skip the phase
         self.skip_role = nconfig().get("skip-role", "owner")
+
+        # Whether wild cards should be replaced in the queue after being played
+        self.wild_replace_mode = nconfig().get("wild-replace-mode", "no")
 
     def put_in_pool(self):
         """Puts this match into the match pool."""
@@ -404,7 +408,8 @@ class Match:
         if self._state == "COOLDOWN":
             # Delete all chosen cards from the hands
             for part in self.get_participants(False):
-                part.delete_chosen()
+                cards = part.delete_chosen()
+                self._replace_wild_cards(cards)
 
     def _enter_state(self):
         """Handles a transition into the current state.
@@ -901,7 +906,8 @@ class Match:
                 else:
                     self._set_state("COOLDOWN")
             else:
-                part.delete_chosen()
+                cards = part.delete_chosen()
+                self._replace_wild_cards(cards)
 
     @mutex
     def check_choosing_done(self):
@@ -974,6 +980,27 @@ class Match:
         for part in self.get_participants(False):
             drawn = part.replenish_hand(self._multidecks, card_count)
             card_count -= drawn
+
+    def _replace_wild_cards(self, cards):
+        """If the match is configured to do so, put any wild cards played during
+        the last round back in the MultiDeck's queue so they can be redrawn by
+        other players in future rounds.
+
+        Args:
+            cards: A list of card objects played during the last round (the ones
+            deleted at the end of the last round).
+
+        Contract:
+            The caller ensures that the match's lock is held when calling this
+            method.
+        """
+        # If the match isn't configured to replace wild cards or there are no
+        # cards to put back, do nothing
+        if self.wild_replace_mode == "no" or len(cards) == 0:
+            return
+        for card in cards:
+            if card.type == "WILD":
+                self.mdecks["WILD"].putInQueue(card)
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -316,6 +316,10 @@ class Match:
     def user_can_skip_phase(self, participant):
         """Determine whether a user can skip to the next phase
 
+        Args:
+            participant: The participant that made the request
+            to skip the phase
+
         Returns:
             bool: Whether the given participant can skip to the next phase
         """
@@ -330,10 +334,7 @@ class Match:
 
         if self.skip_role == "picker":
             if self._state == "CHOOSING":
-                for part in self.get_participants(False):
-                    if part.picking and part.nickname == nickname:
-                        return True
-                return False
+                return participant.picking
             else:
                 return True
         elif self.skip_role == "anyone":

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -315,16 +315,17 @@ class Match:
     def user_can_skip_phase(self, participant):
         """Determine whether a user can skip to the next phase
 
+        Args:
+            participant: The participant that made the request
+            to skip the phase
+
         Returns:
             bool: Whether the given nickname belongs to a user that
             can skip to the next phase
         """
         if self.skip_role == "picker":
             if self._state == "CHOOSING":
-                for part in self.get_participants(False):
-                    if part.picking and part.nickname == nickname:
-                        return True
-                return False
+                return participant.picking
             else:
                 return True
         elif self.skip_role == "anyone":

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -99,9 +99,10 @@ class Match:
     # Which users are allowed to skip the phase
     skip_role = "owner"
 
-    # Number of wild cards in the match
+    # Wild card data
     wild_card_count = 0
-    wild_cards_played = 0
+    wilds_in_play = 0
+    total_cards = 0
 
     @classmethod
     @named_mutex("_pool_lock")
@@ -723,6 +724,12 @@ class Match:
         # Create multidecks
         for type in self._deck:
             self._multidecks[type] = MultiDeck[Card, int](self._deck[type])
+            self.total_cards += len(self._deck[type])
+
+        wilds = [Card(card_id_counter + 1 + i, "WILD", "")
+                for i in range(self.wild_card_count)]
+        self._multidecks["WILD"] = MultiDeck[Card, int](wilds)
+        self.total_cards += self.wild_card_count
 
         return True, "OK"
 
@@ -963,7 +970,8 @@ class Match:
             method.
         """
         for part in self.get_participants(False):
-            part.replenish_hand(self._multidecks)
+            part.replenish_hand(self._multidecks, self.wilds_in_play,
+                                self.total_cards)
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -725,7 +725,7 @@ class Match:
             self._multidecks[type] = MultiDeck[Card, int](self._deck[type])
             self.total_cards += len(self._deck[type])
 
-        wilds = [Card(card_id_counter + 1 + i, "WILD", "")
+        wilds = [Card(card_id_counter + 1 + i, "WILD", "Wild card")
                 for i in range(self.wild_card_count)]
         self._multidecks["WILD"] = MultiDeck[Card, int](wilds)
         self.total_cards += self.wild_card_count

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -968,9 +968,12 @@ class Match:
             The caller ensures that the match's lock is held when calling this
             method.
         """
+        card_count = self.total_cards
         for part in self.get_participants(False):
-            part.replenish_hand(self._multidecks,
-                                self.total_cards)
+            card_count -= part.get_card_count()
+        for part in self.get_participants(False):
+            drawn = part.replenish_hand(self._multidecks, card_count)
+            card_count -= drawn
 
     def _select_match_card(self):
         """Selects a random statement card for this match.

--- a/src/model/match.py
+++ b/src/model/match.py
@@ -330,7 +330,7 @@ class Match:
         elif self.skip_role == "anyone":
             return True
         elif self.skip_role == "majority":
-            particpant.wants_skip = True
+            participant.wants_skip = True
             skip_count = 0
             for part in self.get_participants(False):
                 if part.wants_skip:

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -2,6 +2,7 @@
 
 MIT License
 Copyright (c) 2017-2018 LordKorea
+Copyright (c) 2018 Arc676/Alessandro Vinciguerra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -68,14 +69,15 @@ class MultiDeck(Generic[T, U]):
         return cast(U, id)
 
     @mutex
-    def request(self, banned_ids: Set[U], wilds = None, wilds_in_play = 0,
-                cards_left = 0, banned_wilds: Set[U] = None) -> Optional[T]:
+    def request(self, banned_ids: Set[U], wilds = None, cards_left = 0,
+                banned_wilds: Set[U] = None) -> Optional[T]:
         """Requests a card from the multideck.
 
         Args:
             banned_ids: A set of IDs that may not be chosen.
             wilds: The multideck with the wild cards. Defaults to None
-            wilds_in_play: The number of wild cards currently in players' hands
+            cards_left: The number of cards remaining to be drawn
+            banned_wilds: A set of IDs of wild cards that are aleady drawn
 
         Returns:
             The object that was selected. This might be None if the
@@ -85,7 +87,7 @@ class MultiDeck(Generic[T, U]):
             This method locks the deck's lock.
         """
         if wilds is not None:
-            if randint(1, cards_left) <= len(wilds._backing) - wilds_in_play:
+            if randint(1, cards_left) <= len(wilds._queue):
                 return wilds.request(banned_wilds)
         ptr = 0
 

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -40,11 +40,11 @@ U = TypeVar("U")
 class MultiDeck(Generic[T, U]):
     """A (refilling) deck used to make selection seem more 'random'."""
 
-    def pickFromQueue(self, ptr, banned_ids: Set[U]):
+    def pickFromQueue(self, ptr, banned_ids: Set[U]) -> Optional[T]:
         """Pick a card from the queue
 
         Args:
-            ptr: The index from which to start looking for viable cards
+            ptr: The index from which to start looking for viable cards.
             banned_ids: A set of IDs that may not be chosen.
 
         Returns:
@@ -60,7 +60,7 @@ class MultiDeck(Generic[T, U]):
             ptr += 1
         return None, ptr
 
-    def refillQueue(self):
+    def refillQueue(self) -> None:
         """Refill the card queue
         """
         pool = []

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -142,5 +142,6 @@ class MultiDeck(Generic[T, U]):
         # Try to find a viable object again
         card, ptr = self.pickFromQueue(ptr, banned_ids)
 
-        # Still no object found: Failure, as the queue is already maximal.
+        # If no object found: Failure, as the queue is already maximal.
+        # Otherwise, return the given card
         return card

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -40,7 +40,7 @@ U = TypeVar("U")
 class MultiDeck(Generic[T, U]):
     """A (refilling) deck used to make selection seem more 'random'."""
 
-    def pickFromQueue(self, ptr, banned_ids: Set[U]) -> Optional[T]:
+    def pick_from_queue(self, ptr, banned_ids: Set[U]) -> Optional[T]:
         """Pick a card from the queue
 
         Args:
@@ -60,7 +60,7 @@ class MultiDeck(Generic[T, U]):
             ptr += 1
         return None, ptr
 
-    def refillQueue(self) -> None:
+    def refill_queue(self) -> None:
         """Refill the card queue
         """
         pool = []
@@ -84,7 +84,7 @@ class MultiDeck(Generic[T, U]):
         self._backing = deck  # type: List[T]
         self._queue = []  # type: List[T]
         self._contained = set()  # type: Set[U]
-        self.refillQueue()
+        self.refill_queue()
 
     @staticmethod
     def _id_of(o: T) -> U:
@@ -128,7 +128,7 @@ class MultiDeck(Generic[T, U]):
         ptr = 0
 
         # Try to find a viable object
-        card, ptr = self.pickFromQueue(ptr, banned_ids)
+        card, ptr = self.pick_from_queue(ptr, banned_ids)
         if card is not None:
             return card
 
@@ -137,10 +137,10 @@ class MultiDeck(Generic[T, U]):
         # set of banned ids this might result in less than optimal randomness.
         # However in practice, deck size does exceed the number of banned ids
         # by at least factor 2.
-        self.refillQueue()
+        self.refill_queue()
 
         # Try to find a viable object again
-        card, ptr = self.pickFromQueue(ptr, banned_ids)
+        card, ptr = self.pick_from_queue(ptr, banned_ids)
 
         # If no object found: Failure, as the queue is already maximal.
         # Otherwise, return the given card

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -84,7 +84,7 @@ class MultiDeck(Generic[T, U]):
         Contract:
             This method locks the deck's lock.
         """
-        if wilds != None:
+        if wilds is not None:
             if randint(1, cards_left) <= len(wilds._backing) - wilds_in_play:
                 return wilds.request(banned_wilds)
         ptr = 0

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -41,7 +41,7 @@ class MultiDeck(Generic[T, U]):
     """A (refilling) deck used to make selection seem more 'random'."""
 
     @mutex
-    def putInQueue(self, obj):
+    def put_in_queue(self, obj):
         """Put a card in the queue (used to allow wild cards to be redrawn
         after being played for the first time, but also to build the queue)
 
@@ -54,7 +54,7 @@ class MultiDeck(Generic[T, U]):
         self._contained.add(MultiDeck._id_of(obj))
         self._queue.append(obj)
 
-    def pickFromQueue(self, ptr, banned_ids: Set[U]) -> Optional[T]:
+    def pick_from_queue(self, ptr, banned_ids: Set[U]) -> Optional[T]:
         """Pick a card from the queue
 
         Args:
@@ -83,7 +83,7 @@ class MultiDeck(Generic[T, U]):
                 pool.append(obj)
         shuffle(pool)
         for obj in pool:
-            self.putInQueue(obj)
+            self.put_in_queue(obj)
 
     def __init__(self, deck: List[T]) -> None:
         """Constructor.

--- a/src/model/multideck.py
+++ b/src/model/multideck.py
@@ -25,7 +25,7 @@ Module Deadlock Guarantees:
     requested. Thus the multideck lock can not be part of any deadlock.
 """
 
-from random import shuffle
+from random import shuffle, randint
 from threading import RLock
 from typing import Generic, List, Optional, Set, TypeVar, cast
 
@@ -68,11 +68,14 @@ class MultiDeck(Generic[T, U]):
         return cast(U, id)
 
     @mutex
-    def request(self, banned_ids: Set[U]) -> Optional[T]:
+    def request(self, banned_ids: Set[U], wilds = None, wilds_in_play = 0,
+                cards_left = 0, banned_wilds: Set[U] = None) -> Optional[T]:
         """Requests a card from the multideck.
 
         Args:
             banned_ids: A set of IDs that may not be chosen.
+            wilds: The multideck with the wild cards. Defaults to None
+            wilds_in_play: The number of wild cards currently in players' hands
 
         Returns:
             The object that was selected. This might be None if the
@@ -81,6 +84,9 @@ class MultiDeck(Generic[T, U]):
         Contract:
             This method locks the deck's lock.
         """
+        if wilds != None:
+            if randint(1, cards_left) <= len(wilds._backing) - wilds_in_play:
+                return wilds.request(banned_wilds)
         ptr = 0
 
         # Try to find a viable object

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -140,8 +140,12 @@ class Participant:
             hcard.chosen = None
 
     @mutex
-    def delete_chosen(self) -> None:
+    def delete_chosen(self) -> List["Card"]:
         """Deletes all chosen hand cards from this participant.
+
+        Returns:
+            A list of deep-copied Card objects corresponding to the cards
+            removed from the participant's hand.
 
         Contract:
             This method locks the participant's lock.
@@ -151,7 +155,9 @@ class Participant:
         for hid, hcard in self._hand.items():
             if hcard.chosen is not None:
                 del_list.append(hid)
+        cards = []
         for hid in del_list:
+            cards.append(deepcopy(self._hand[hid].card))
             del self._hand[hid]
 
     @mutex

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -203,7 +203,7 @@ class Participant:
                 banned_wilds.add(hcard.card.id)
 
         # Replenish for every type
-        for type in filter(lambda x: x != "STATEMENT", mdecks):
+        for type in filter(lambda x: x != "STATEMENT" and x != "WILD", mdecks):
             # Count cards of that type and fetch IDs
             k_in_hand = 0
             ids_banned = set()  # type: Set[int]

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -159,6 +159,7 @@ class Participant:
         for hid in del_list:
             cards.append(deepcopy(self._hand[hid].card))
             del self._hand[hid]
+        return cards
 
     @mutex
     def get_hand(self) -> Dict[int, "HandCard"]:

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -261,6 +261,19 @@ class Participant:
                         other_hcard.chosen = None
 
     @mutex
+    def set_card_text(self, handid, text):
+        """Changes the text on a given card. To be used for wild cards.
+
+        Args:
+            handid: The ID of the hand card.
+            text: The new text for the card.
+
+        Contract:
+            This method locks the participant's lock.
+        """
+        self._hand[handid].card.text = text
+
+    @mutex
     def get_choose_data(self, redacted: bool
                         ) -> List[Optional[Dict[str, Union[bool, str]]]]:
         """Fetches the choose data for this participant.

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -31,6 +31,7 @@ from copy import deepcopy
 from threading import RLock
 from time import time
 from typing import Dict, List, Mapping, Optional, Set, TYPE_CHECKING, Union
+from math import floor, ceil
 
 from nussschale.util.locks import mutex
 
@@ -216,9 +217,11 @@ class Participant:
 
         # Find any wild cards already held
         banned_wilds = set()
+        wilds_in_hand = 0
         for hcard in self._hand.values():
             if hcard.card.type == "WILD":
                 banned_wilds.add(hcard.card.id)
+                wilds_in_hand += 1
 
         # Replenish for every type
         for type in filter(lambda x: x != "STATEMENT" and x != "WILD", mdecks):
@@ -229,6 +232,12 @@ class Participant:
                 if hcard.card.type == type:
                     ids_banned.add(hcard.card.id)
                     k_in_hand += 1
+
+            # Reduce number of cards to draw if wild cards are in hand
+            if type == "OBJECT":
+                k_in_hand += floor(wilds_in_hand / 2)
+            else:
+                k_in_hand += ceil(wilds_in_hand / 2)
 
             # Fill hand to limit
             for i in range(Participant._HAND_CARDS_PER_TYPE - k_in_hand):

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -2,6 +2,7 @@
 
 MIT License
 Copyright (c) 2017-2018 LordKorea
+Copyright (c) 2018 Arc676/Alessandro Vinciguerra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -184,12 +185,12 @@ class Participant:
 
     @mutex
     def replenish_hand(self, mdecks: Mapping[str, "MultiDeck[Card, int]"],
-                       wilds_in_play, cards_left) -> None:
+                       cards_left) -> None:
         """Replenishes the hand of this participant from the given decks.
 
         Args:
             mdecks: Maps card type to a multideck of the card type.
-            wilds_in_play: Number of wild cards currently in players' hands
+            cards_left: Number of cards remaining to be drawn
 
         Contract:
             This method locks the participant's lock.
@@ -215,8 +216,7 @@ class Participant:
             # Fill hand to limit
             for i in range(Participant._HAND_CARDS_PER_TYPE - k_in_hand):
                 pick = mdecks[type].request(ids_banned, mdecks["WILD"],
-                                            wilds_in_play, cards_left,
-                                            banned_wilds)
+                                            cards_left, banned_wilds)
                 if pick is None:
                     break  # Can't fulfill the requirement...
                 ids_banned.add(pick.id)

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -215,7 +215,8 @@ class Participant:
             # Fill hand to limit
             for i in range(Participant._HAND_CARDS_PER_TYPE - k_in_hand):
                 pick = mdecks[type].request(ids_banned, mdecks["WILD"],
-                                            wilds_in_play, cards_left)
+                                            wilds_in_play, cards_left,
+                                            banned_wilds)
                 if pick is None:
                     break  # Can't fulfill the requirement...
                 ids_banned.add(pick.id)

--- a/src/model/participant.py
+++ b/src/model/participant.py
@@ -52,6 +52,7 @@ class Participant:
             occurring.
         order: The order key of the particpant, used for shuffling.
         spectator: Whether the participant is a spectator.
+        wants_skip: Whether the participant wants to skip the phase.
     """
 
     # The number of hand cards per type
@@ -93,6 +94,9 @@ class Participant:
         # Whether this participant is a spectator. Should not change after the
         # participant is part of a match.
         self.spectator = False
+
+        # Whether the particpant wants to skip the phase.
+        self.wants_skip = False
 
         # The hand of this participant
         self._hand = OrderedDict()  # type: Dict[int, HandCard]

--- a/src/nussschale/handler.py
+++ b/src/nussschale/handler.py
@@ -325,13 +325,16 @@ class ServerHandler(BaseHTTPRequestHandler):
                 assert isinstance(param.value, str)
                 return param.value
             else:
-                fp = param.file
-                fp.seek(0, 2)
-                size = fp.tell()
-                fp.seek(0)
-                nlog().log("File upload: '%s', %i bytes" % (param.filename,
-                                                            size))
-                return IOWrapper(param.file, param)
+                if param.filename == None:
+                    return param.value
+                else :
+                    fp = param.file
+                    fp.seek(0, 2)
+                    size = fp.tell()
+                    fp.seek(0)
+                    nlog().log("File upload: '%s', %i bytes" % (param.filename,
+                                                                size))
+                    return IOWrapper(param.file, param)
         else:
             raise ValueError("Unsupported parameter type")
 

--- a/src/nussschale/handler.py
+++ b/src/nussschale/handler.py
@@ -2,6 +2,7 @@
 
 MIT License
 Copyright (c) 2017-2018 LordKorea
+Copyright (c) 2018 Arc676/Alessandro Vinciguerra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -170,6 +170,10 @@ def api_choose(ctx: EndpointContext) -> None:
     except ValueError:
         raise HTTPException.forbidden(True, "invalid id")
 
+    text = ctx.get_param_as("text", str)
+    if text != "":
+        part.set_card_text(handid, text)
+
     part.toggle_chosen(handid, match.count_gaps())  # todo: check for wrong id
     match.check_choosing_done()
     ctx.json_ok()

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -200,7 +200,8 @@ def api_cards(ctx: EndpointContext) -> None:
     if not part.spectator:
         hand_cards = {
             "OBJECT": {},
-            "VERB": {}
+            "VERB": {},
+            "WILD": {}
         }  # type: Dict[str, Dict]
         hand = part.get_hand()
         for id, hcard in hand.items():

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -316,7 +316,7 @@ def api_skip(ctx: EndpointContext) -> None:
         raise HTTPException.forbidden(True, "not authorized to skip phase")
 
     # Skip remaining time
-    match.skip_to_next_phase()
+    match.skip_to_next_phase(part.nickname)
     ctx.json_ok()
 
 

--- a/src/pages/api.py
+++ b/src/pages/api.py
@@ -312,7 +312,7 @@ def api_skip(ctx: EndpointContext) -> None:
     part = match.get_participant(ctx.session["id"])
 
     # Check that the POST request was made by a user that can skip phases
-    if not match.user_can_skip_phase(part.nickname):
+    if not match.user_can_skip_phase(part):
         raise HTTPException.forbidden(True, "not authorized to skip phase")
 
     # Skip remaining time

--- a/src/pages/match.py
+++ b/src/pages/match.py
@@ -124,6 +124,7 @@ def create_match(ctx: EndpointContext) -> None:
 
     # Create a new match
     match = Match()
+    match.wild_card_count = ctx.get_param_as("wildcards", int)
 
     # Create the deck from the upload
     try:

--- a/src/pages/match.py
+++ b/src/pages/match.py
@@ -2,6 +2,7 @@
 
 MIT License
 Copyright (c) 2017-2018 LordKorea
+Copyright (c) 2018 Arc676/Alessandro Vinciguerra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/res/css/dark/deck.css
+++ b/src/res/css/dark/deck.css
@@ -36,6 +36,16 @@
   color: #441;
 }
 
+.wild-card {
+  color: #001;
+  background-color: #BBB;
+}
+
+.wild-card a, .wild-card a:link, .wild-card a:visited, .wild-card a:hover,
+    .wild-card a:active {
+  color: #441;
+}
+
 .knob-statement {
   background-color: #444;
 }

--- a/src/res/css/light/deck.css
+++ b/src/res/css/light/deck.css
@@ -31,6 +31,11 @@
   background-color: #DD9;
 }
 
+.wild-card {
+  color: #111;
+  background-color: #DDD;
+}
+
 .knob-statement {
   background-color: #444;
 }

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -352,10 +352,17 @@
     if (!allowChoose) {
       return
     }
+    var data = {
+      "handId": id,
+      "text": ""
+    }
+    if (id in handResolver.get("WILD")) {
+      data["text"] = prompt("Enter card text:")
+    }
     $.ajax({
       method: "POST",
       url: "/api/choose",
-      data: {"handId": id},
+      data: data,
       success: () => updateSelection(id),
       error: (x, e, f) => console.log(`/api/choose error: ${e} ${f}`)
     })

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -351,10 +351,17 @@
     if (!allowChoose) {
       return
     }
+    var data = {
+      "handId": id,
+      "text": ""
+    }
+    if (id in handResolver.get("WILD")) {
+      data["text"] = prompt("Enter card text:")
+    }
     $.ajax({
       method: "POST",
       url: "/api/choose",
-      data: {"handId": id},
+      data: data,
       success: () => updateSelection(id),
       error: (x, e, f) => console.log(`/api/choose error: ${e} ${f}`)
     })

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -356,7 +356,10 @@
       "handId": id,
       "text": ""
     }
-    if (id in handResolver.get("WILD")) {
+    // Ask user for custom card text if the card isn't already selected and
+    // it's a wild card.
+    if (id in handResolver.get("WILD") &&
+        !handResolver.get("WILD").get(id).hasClass("card-selected")) {
       data["text"] = prompt("Enter card text:")
     }
     $.ajax({

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -355,7 +355,10 @@
       "handId": id,
       "text": ""
     }
-    if (id in handResolver.get("WILD")) {
+    // Ask user for custom card text if the card isn't already selected and
+    // it's a wild card.
+    if (id in handResolver.get("WILD") &&
+        !handResolver.get("WILD").get(id).hasClass("card-selected")) {
       data["text"] = prompt("Enter card text:")
     }
     $.ajax({

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -424,6 +424,7 @@
       method: "POST",
       url: "/api/skip"
     })
+  }
 
   /*
    * Toggle hand visibility.

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -35,7 +35,8 @@
   let externalUpdateAllowed = true
   let handResolver = new Map([
     ["OBJECT", new Map()],
-    ["VERB", new Map()]
+    ["VERB", new Map()],
+    ["WILD", new Map()]
   ])
   let numSelected = 0
   let selectedCards = new Map()
@@ -131,7 +132,8 @@
   function updateCards(data) {
     let sentHand = new Map([
       ["OBJECT", new Map()],
-      ["VERB", new Map()]
+      ["VERB", new Map()],
+      ["WILD", new Map()]
     ])
     if (data.hasOwnProperty("hand")) {
       for (let type of sentHand.keys()) {
@@ -418,6 +420,13 @@
   }
 
   /**
+   * Chooses the wild cards tab.
+   */
+  function chooseWildsTab() {
+    pickTab("tab-wilds")
+  }
+
+  /**
    * Sends POST request to skip the remaining time
    */
   function skipTime() {
@@ -457,6 +466,7 @@
   pickTab("tab-actions")
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
+  $("#tab-wilds").click(chooseWildsTab)
   $("#skip-button").click(skipTime)
   $("#toggle-hand-button").click(toggleHand)
   $("#toggle-chat-button").click(toggleChat)

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -358,7 +358,7 @@
     }
     // Ask user for custom card text if the card isn't already selected and
     // it's a wild card.
-    if (id in handResolver.get("WILD") &&
+    if (handResolver.get("WILD").has(id) &&
         !handResolver.get("WILD").get(id).hasClass("card-selected")) {
       data["text"] = prompt("Enter card text:")
     }
@@ -383,6 +383,7 @@
     let remove = false
     let card = handResolver.get("OBJECT").get(id)
     card = card || handResolver.get("VERB").get(id)
+    card = card || handResolver.get("WILD").get(id)
 
     // Remove card choices
     for (let i = 0; i < 4; i++) {

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -35,7 +35,8 @@
   let externalUpdateAllowed = true
   let handResolver = new Map([
     ["OBJECT", new Map()],
-    ["VERB", new Map()]
+    ["VERB", new Map()],
+    ["WILD", new Map()]
   ])
   let numSelected = 0
   let selectedCards = new Map()
@@ -130,7 +131,8 @@
   function updateCards(data) {
     let sentHand = new Map([
       ["OBJECT", new Map()],
-      ["VERB", new Map()]
+      ["VERB", new Map()],
+      ["WILD", new Map()]
     ])
     if (data.hasOwnProperty("hand")) {
       for (let type of sentHand.keys()) {
@@ -417,6 +419,13 @@
   }
 
   /**
+   * Chooses the wild cards tab.
+   */
+  function chooseWildsTab() {
+    pickTab("tab-wilds")
+  }
+
+  /**
    * Sends POST request to skip the remaining time
    */
   function skipTime() {
@@ -455,6 +464,7 @@
   pickTab("tab-actions")
   $("#tab-actions").click(chooseActionsTab)
   $("#tab-objects").click(chooseObjectsTab)
+  $("#tab-wilds").click(chooseWildsTab)
   $("#skip-button").click(skipTime)
   $("#toggle-hand-button").click(toggleHand)
   $("#toggle-chat-button").click(toggleChat)

--- a/src/res/js/match/match.js
+++ b/src/res/js/match/match.js
@@ -357,7 +357,7 @@
     }
     // Ask user for custom card text if the card isn't already selected and
     // it's a wild card.
-    if (id in handResolver.get("WILD") &&
+    if (handResolver.get("WILD").has(id) &&
         !handResolver.get("WILD").get(id).hasClass("card-selected")) {
       data["text"] = prompt("Enter card text:")
     }
@@ -382,6 +382,7 @@
     let remove = false
     let card = handResolver.get("OBJECT").get(id)
     card = card || handResolver.get("VERB").get(id)
+    card = card || handResolver.get("WILD").get(id)
 
     // Remove card choices
     for (let i = 0; i < 4; i++) {

--- a/src/res/tpl/dashboard.html
+++ b/src/res/tpl/dashboard.html
@@ -66,6 +66,8 @@
     <form action="/match/create" method="POST" enctype="multipart/form-data">
       <div class="match-box match-box-contents">
         <div>
+          Number of blank cards:
+          <input type="number" name="wildcards" min="0" max="5" value="0">
           <span class="hint">Choose a deck...</span>
           <input type="file" name="deckupload" required="required" accept=".tsv">
           <span class="hint">(Maximum file size for decks is <b>800kB</b>)</span>

--- a/src/res/tpl/dashboard.html
+++ b/src/res/tpl/dashboard.html
@@ -67,7 +67,7 @@
       <div class="match-box match-box-contents">
         <div>
           Number of blank cards:
-          <input type="number" name="wildcards" min="0" max="5" value="0">
+          <input type="number" name="wildcards" min="0" max="100" value="0">
           <span class="hint">Choose a deck...</span>
           <input type="file" name="deckupload" required="required" accept=".tsv">
           <span class="hint">(Maximum file size for decks is <b>800kB</b>)</span>

--- a/src/res/tpl/match.html
+++ b/src/res/tpl/match.html
@@ -69,12 +69,18 @@
           <div class="hand-tab-header" id="tab-objects">
             Objects
           </div>
+          <div class="hand-tab-header" id="tab-wilds">
+            Wild cards
+          </div>
         </div>
         <div class="match-hand-content">
           <div class="hand-set tab-actions" id="verb-hand">
             <div class="card-base system-card">No cards on your hand.</div>
           </div>
           <div class="hand-set tab-objects" id="object-hand">
+            <div class="card-base system-card">No cards on your hand.</div>
+          </div>
+          <div class="hand-set tab-wilds" id="wild-hand">
             <div class="card-base system-card">No cards on your hand.</div>
           </div>
         </div>


### PR DESCRIPTION
To be merged after #49.

The `wild-replace-mode` option in the configuration file specifies whether wild cards are returned to the queue after being played, allowing them to be redrawn later in the game.

Currently, setting this option to `"no"` prevents wild cards from being replaced. Any other value enables wild card replacement.